### PR TITLE
Using Assembly.LoadFrom instead of LoadFile so that PropertyType and …

### DIFF
--- a/MarkdownDocNet/DocParser.cs
+++ b/MarkdownDocNet/DocParser.cs
@@ -69,7 +69,7 @@ namespace MarkdownDocNet
         public DocParser(string docFile, string assemblyFile, string outputFile)
         {
             Doc = XDocument.Load(docFile, LoadOptions.SetLineInfo);
-            AssemblyInfo = Assembly.LoadFile(assemblyFile);
+            AssemblyInfo = Assembly.LoadFrom(assemblyFile);
             OutputFile = outputFile;
         }
 


### PR DESCRIPTION
Using Assembly.LoadFrom instead of LoadFile so that PropertyType and GetProperties() works from referenced assemblies.